### PR TITLE
Add catalog service foundation

### DIFF
--- a/shoplite/.gitignore
+++ b/shoplite/.gitignore
@@ -1,0 +1,9 @@
+/target/
+**/target/
+!.mvn/wrapper/maven-wrapper.jar
+.mvn/wrapper/maven-wrapper.jar
+.mvn/
+.idea/
+*.iml
+*.log
+.DS_Store

--- a/shoplite/README.md
+++ b/shoplite/README.md
@@ -1,0 +1,52 @@
+# ShopLite Platform
+
+This repository hosts the evolving ShopLite microservices platform. The first milestone introduces the **catalog-service**, a Spring Boot application that provides CRUD operations for managing product metadata.
+
+## Modules
+
+- `catalog-service` – exposes REST APIs for creating, reading, updating and deleting products. Uses Spring Data JPA with Flyway migrations and is ready for PostgreSQL deployments.
+
+## Getting Started
+
+### Prerequisites
+
+- JDK 17+
+- Maven 3.9+
+- Optional: Docker (for running PostgreSQL locally)
+
+### Run Tests
+
+```bash
+mvn test
+```
+
+> **Note:** The project depends on Maven Central to download Spring Boot artifacts.
+
+### Run the Catalog Service
+
+```bash
+mvn -pl catalog-service spring-boot:run
+```
+
+The service listens on `http://localhost:8081` by default.
+
+### Sample Requests
+
+```bash
+curl -X POST http://localhost:8081/api/products \
+  -H "Content-Type: application/json" \
+  -d '{"name":"pen","price":10.0,"stockQty":100}'
+```
+
+```bash
+curl http://localhost:8081/api/products
+```
+
+## Database Configuration
+
+- **Development (default)**: In-memory H2 database with Flyway migrations.
+- **Production**: Configure the `application-prod.yml` profile to point at a PostgreSQL instance.
+
+## Health Checks
+
+The service exposes Actuator endpoints with `/actuator/health`, `/actuator/info`, and `/actuator/metrics` enabled.

--- a/shoplite/catalog-service/pom.xml
+++ b/shoplite/catalog-service/pom.xml
@@ -1,0 +1,71 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.shoplite</groupId>
+        <artifactId>shoplite</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>catalog-service</artifactId>
+    <name>catalog-service</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/shoplite/catalog-service/src/main/java/com/shoplite/catalog/CatalogServiceApplication.java
+++ b/shoplite/catalog-service/src/main/java/com/shoplite/catalog/CatalogServiceApplication.java
@@ -1,0 +1,12 @@
+package com.shoplite.catalog;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CatalogServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CatalogServiceApplication.class, args);
+    }
+}

--- a/shoplite/catalog-service/src/main/java/com/shoplite/catalog/controller/ProductController.java
+++ b/shoplite/catalog-service/src/main/java/com/shoplite/catalog/controller/ProductController.java
@@ -1,0 +1,53 @@
+package com.shoplite.catalog.controller;
+
+import com.shoplite.catalog.dto.ProductRequest;
+import com.shoplite.catalog.dto.ProductResponse;
+import com.shoplite.catalog.service.ProductService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+    @GetMapping
+    public List<ProductResponse> getProducts() {
+        return productService.getAllProducts();
+    }
+
+    @GetMapping("/{id}")
+    public ProductResponse getProduct(@PathVariable Long id) {
+        return productService.getProduct(id);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ProductResponse createProduct(@RequestBody @Valid ProductRequest request) {
+        return productService.createProduct(request);
+    }
+
+    @PutMapping("/{id}")
+    public ProductResponse updateProduct(@PathVariable Long id, @RequestBody @Valid ProductRequest request) {
+        return productService.updateProduct(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteProduct(@PathVariable Long id) {
+        productService.deleteProduct(id);
+    }
+}

--- a/shoplite/catalog-service/src/main/java/com/shoplite/catalog/domain/Product.java
+++ b/shoplite/catalog-service/src/main/java/com/shoplite/catalog/domain/Product.java
@@ -1,0 +1,37 @@
+package com.shoplite.catalog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "products")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(nullable = false, precision = 19, scale = 2)
+    private BigDecimal price;
+
+    @Column(name = "stock_qty", nullable = false)
+    private Integer stockQty;
+}

--- a/shoplite/catalog-service/src/main/java/com/shoplite/catalog/dto/ProductRequest.java
+++ b/shoplite/catalog-service/src/main/java/com/shoplite/catalog/dto/ProductRequest.java
@@ -1,0 +1,13 @@
+package com.shoplite.catalog.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+
+public record ProductRequest(
+        @NotBlank(message = "Product name is required") String name,
+        @NotNull(message = "Price is required") @Positive(message = "Price must be positive") BigDecimal price,
+        @NotNull(message = "Stock quantity is required") @Min(value = 0, message = "Stock quantity cannot be negative") Integer stockQty) {
+}

--- a/shoplite/catalog-service/src/main/java/com/shoplite/catalog/dto/ProductResponse.java
+++ b/shoplite/catalog-service/src/main/java/com/shoplite/catalog/dto/ProductResponse.java
@@ -1,0 +1,6 @@
+package com.shoplite.catalog.dto;
+
+import java.math.BigDecimal;
+
+public record ProductResponse(Long id, String name, BigDecimal price, Integer stockQty) {
+}

--- a/shoplite/catalog-service/src/main/java/com/shoplite/catalog/exception/ApiError.java
+++ b/shoplite/catalog-service/src/main/java/com/shoplite/catalog/exception/ApiError.java
@@ -1,0 +1,7 @@
+package com.shoplite.catalog.exception;
+
+import java.time.Instant;
+import java.util.List;
+
+public record ApiError(Instant timestamp, int status, String error, String message, List<String> details) {
+}

--- a/shoplite/catalog-service/src/main/java/com/shoplite/catalog/exception/DuplicateResourceException.java
+++ b/shoplite/catalog-service/src/main/java/com/shoplite/catalog/exception/DuplicateResourceException.java
@@ -1,0 +1,7 @@
+package com.shoplite.catalog.exception;
+
+public class DuplicateResourceException extends RuntimeException {
+    public DuplicateResourceException(String message) {
+        super(message);
+    }
+}

--- a/shoplite/catalog-service/src/main/java/com/shoplite/catalog/exception/GlobalExceptionHandler.java
+++ b/shoplite/catalog-service/src/main/java/com/shoplite/catalog/exception/GlobalExceptionHandler.java
@@ -1,0 +1,78 @@
+package com.shoplite.catalog.exception;
+
+import jakarta.validation.ConstraintViolationException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ApiError> handleNotFound(ResourceNotFoundException ex) {
+        ApiError error = new ApiError(
+                Instant.now(),
+                HttpStatus.NOT_FOUND.value(),
+                HttpStatus.NOT_FOUND.getReasonPhrase(),
+                ex.getMessage(),
+                Collections.emptyList());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+
+    @ExceptionHandler(DuplicateResourceException.class)
+    public ResponseEntity<ApiError> handleDuplicate(DuplicateResourceException ex) {
+        ApiError error = new ApiError(
+                Instant.now(),
+                HttpStatus.CONFLICT.value(),
+                HttpStatus.CONFLICT.getReasonPhrase(),
+                ex.getMessage(),
+                Collections.emptyList());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex) {
+        List<String> details = ex.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.toList());
+        ApiError error = new ApiError(
+                Instant.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "Validation failed",
+                details);
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiError> handleConstraintViolation(ConstraintViolationException ex) {
+        List<String> details = ex.getConstraintViolations().stream()
+                .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+                .collect(Collectors.toList());
+        ApiError error = new ApiError(
+                Instant.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "Validation failed",
+                details);
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiError> handleGeneric(Exception ex) {
+        ApiError error = new ApiError(
+                Instant.now(),
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+                ex.getMessage(),
+                Collections.emptyList());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+}

--- a/shoplite/catalog-service/src/main/java/com/shoplite/catalog/exception/ResourceNotFoundException.java
+++ b/shoplite/catalog-service/src/main/java/com/shoplite/catalog/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.shoplite.catalog.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/shoplite/catalog-service/src/main/java/com/shoplite/catalog/mapper/ProductMapper.java
+++ b/shoplite/catalog-service/src/main/java/com/shoplite/catalog/mapper/ProductMapper.java
@@ -1,0 +1,29 @@
+package com.shoplite.catalog.mapper;
+
+import com.shoplite.catalog.domain.Product;
+import com.shoplite.catalog.dto.ProductRequest;
+import com.shoplite.catalog.dto.ProductResponse;
+
+public final class ProductMapper {
+
+    private ProductMapper() {
+    }
+
+    public static Product toEntity(ProductRequest request) {
+        return Product.builder()
+                .name(request.name().trim())
+                .price(request.price())
+                .stockQty(request.stockQty())
+                .build();
+    }
+
+    public static void updateEntity(Product product, ProductRequest request) {
+        product.setName(request.name().trim());
+        product.setPrice(request.price());
+        product.setStockQty(request.stockQty());
+    }
+
+    public static ProductResponse toResponse(Product product) {
+        return new ProductResponse(product.getId(), product.getName(), product.getPrice(), product.getStockQty());
+    }
+}

--- a/shoplite/catalog-service/src/main/java/com/shoplite/catalog/repository/ProductRepository.java
+++ b/shoplite/catalog-service/src/main/java/com/shoplite/catalog/repository/ProductRepository.java
@@ -1,0 +1,9 @@
+package com.shoplite.catalog.repository;
+
+import com.shoplite.catalog.domain.Product;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+    Optional<Product> findByNameIgnoreCase(String name);
+}

--- a/shoplite/catalog-service/src/main/java/com/shoplite/catalog/service/ProductService.java
+++ b/shoplite/catalog-service/src/main/java/com/shoplite/catalog/service/ProductService.java
@@ -1,0 +1,69 @@
+package com.shoplite.catalog.service;
+
+import com.shoplite.catalog.domain.Product;
+import com.shoplite.catalog.dto.ProductRequest;
+import com.shoplite.catalog.dto.ProductResponse;
+import com.shoplite.catalog.exception.DuplicateResourceException;
+import com.shoplite.catalog.exception.ResourceNotFoundException;
+import com.shoplite.catalog.mapper.ProductMapper;
+import com.shoplite.catalog.repository.ProductRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    @Transactional(readOnly = true)
+    public List<ProductResponse> getAllProducts() {
+        log.info("Fetching all products");
+        return productRepository.findAll().stream().map(ProductMapper::toResponse).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ProductResponse getProduct(Long id) {
+        log.info("Fetching product with id={}", id);
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Product not found with id=" + id));
+        return ProductMapper.toResponse(product);
+    }
+
+    @Transactional
+    public ProductResponse createProduct(ProductRequest request) {
+        log.info("Creating product name={} stockQty={}", request.name(), request.stockQty());
+        productRepository.findByNameIgnoreCase(request.name()).ifPresent(product -> {
+            throw new DuplicateResourceException("Product already exists with name=" + request.name());
+        });
+        Product product = ProductMapper.toEntity(request);
+        Product saved = productRepository.save(product);
+        return ProductMapper.toResponse(saved);
+    }
+
+    @Transactional
+    public ProductResponse updateProduct(Long id, ProductRequest request) {
+        log.info("Updating product id={}", id);
+        Product existing = productRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Product not found with id=" + id));
+        productRepository.findByNameIgnoreCase(request.name())
+                .filter(product -> !product.getId().equals(id))
+                .ifPresent(product -> {
+                    throw new DuplicateResourceException("Product already exists with name=" + request.name());
+                });
+        ProductMapper.updateEntity(existing, request);
+        return ProductMapper.toResponse(existing);
+    }
+
+    @Transactional
+    public void deleteProduct(Long id) {
+        log.info("Deleting product id={}", id);
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Product not found with id=" + id));
+        productRepository.delete(product);
+    }
+}

--- a/shoplite/catalog-service/src/main/resources/application-dev.yml
+++ b/shoplite/catalog-service/src/main/resources/application-dev.yml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:catalogdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: false
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+logging:
+  level:
+    com.shoplite.catalog: INFO

--- a/shoplite/catalog-service/src/main/resources/application-prod.yml
+++ b/shoplite/catalog-service/src/main/resources/application-prod.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/catalog_db
+    username: catalog_user
+    password: catalog_pass
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+  sql:
+    init:
+      mode: never

--- a/shoplite/catalog-service/src/main/resources/application.yml
+++ b/shoplite/catalog-service/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  application:
+    name: catalog-service
+  profiles:
+    active: dev
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+server:
+  port: 8081

--- a/shoplite/catalog-service/src/main/resources/db/migration/V1__init.sql
+++ b/shoplite/catalog-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS products (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    price NUMERIC(19, 2) NOT NULL,
+    stock_qty INTEGER NOT NULL
+);

--- a/shoplite/catalog-service/src/test/java/com/shoplite/catalog/controller/ProductControllerTest.java
+++ b/shoplite/catalog-service/src/test/java/com/shoplite/catalog/controller/ProductControllerTest.java
@@ -1,0 +1,89 @@
+package com.shoplite.catalog.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shoplite.catalog.dto.ProductRequest;
+import com.shoplite.catalog.dto.ProductResponse;
+import com.shoplite.catalog.service.ProductService;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = ProductController.class)
+class ProductControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ProductService productService;
+
+    @Test
+    void shouldReturnAllProducts() throws Exception {
+        when(productService.getAllProducts())
+                .thenReturn(List.of(new ProductResponse(1L, "Pen", BigDecimal.TEN, 100)));
+
+        mockMvc.perform(get("/api/products"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("Pen"));
+    }
+
+    @Test
+    void shouldCreateProduct() throws Exception {
+        ProductRequest request = new ProductRequest("Pen", BigDecimal.TEN, 100);
+        ProductResponse response = new ProductResponse(1L, "Pen", BigDecimal.TEN, 100);
+        when(productService.createProduct(any(ProductRequest.class))).thenReturn(response);
+
+        mockMvc.perform(post("/api/products")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1L));
+    }
+
+    @Test
+    void shouldValidateCreateProduct() throws Exception {
+        ProductRequest invalid = new ProductRequest("", BigDecimal.valueOf(-1), -5);
+
+        mockMvc.perform(post("/api/products")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldUpdateProduct() throws Exception {
+        ProductRequest request = new ProductRequest("Pencil", BigDecimal.valueOf(1.5), 50);
+        ProductResponse response = new ProductResponse(1L, "Pencil", BigDecimal.valueOf(1.5), 50);
+        when(productService.updateProduct(Mockito.eq(1L), any(ProductRequest.class))).thenReturn(response);
+
+        mockMvc.perform(put("/api/products/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Pencil"));
+    }
+
+    @Test
+    void shouldDeleteProduct() throws Exception {
+        mockMvc.perform(delete("/api/products/1"))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/shoplite/catalog-service/src/test/java/com/shoplite/catalog/service/ProductServiceTest.java
+++ b/shoplite/catalog-service/src/test/java/com/shoplite/catalog/service/ProductServiceTest.java
@@ -1,0 +1,120 @@
+package com.shoplite.catalog.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.shoplite.catalog.domain.Product;
+import com.shoplite.catalog.dto.ProductRequest;
+import com.shoplite.catalog.dto.ProductResponse;
+import com.shoplite.catalog.exception.DuplicateResourceException;
+import com.shoplite.catalog.exception.ResourceNotFoundException;
+import com.shoplite.catalog.repository.ProductRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ProductService productService;
+
+    private Product product;
+    private ProductRequest request;
+
+    @BeforeEach
+    void setUp() {
+        product = Product.builder()
+                .id(1L)
+                .name("Pen")
+                .price(BigDecimal.TEN)
+                .stockQty(100)
+                .build();
+        request = new ProductRequest("Pen", BigDecimal.TEN, 100);
+    }
+
+    @Test
+    void shouldReturnAllProducts() {
+        when(productRepository.findAll()).thenReturn(List.of(product));
+
+        List<ProductResponse> responses = productService.getAllProducts();
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).name()).isEqualTo("Pen");
+    }
+
+    @Test
+    void shouldReturnProductById() {
+        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+
+        ProductResponse response = productService.getProduct(1L);
+
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.name()).isEqualTo("Pen");
+    }
+
+    @Test
+    void shouldThrowWhenProductNotFound() {
+        when(productRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> productService.getProduct(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void shouldCreateProduct() {
+        when(productRepository.findByNameIgnoreCase("Pen")).thenReturn(Optional.empty());
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+
+        ProductResponse response = productService.createProduct(request);
+
+        assertThat(response.id()).isEqualTo(1L);
+        verify(productRepository).save(any(Product.class));
+    }
+
+    @Test
+    void shouldPreventDuplicateProductCreation() {
+        when(productRepository.findByNameIgnoreCase("Pen")).thenReturn(Optional.of(product));
+
+        assertThatThrownBy(() -> productService.createProduct(request))
+                .isInstanceOf(DuplicateResourceException.class);
+    }
+
+    @Test
+    void shouldUpdateProduct() {
+        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+        when(productRepository.findByNameIgnoreCase("Pen")).thenReturn(Optional.of(product));
+
+        ProductRequest updateRequest = new ProductRequest("Pen", BigDecimal.valueOf(12.5), 120);
+
+        ProductResponse response = productService.updateProduct(1L, updateRequest);
+
+        assertThat(response.price()).isEqualByComparingTo("12.5");
+        assertThat(response.stockQty()).isEqualTo(120);
+    }
+
+    @Test
+    void shouldDeleteProduct() {
+        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+        doNothing().when(productRepository).delete(product);
+
+        productService.deleteProduct(1L);
+
+        verify(productRepository).delete(product);
+    }
+}

--- a/shoplite/pom.xml
+++ b/shoplite/pom.xml
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.shoplite</groupId>
+    <artifactId>shoplite</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>shoplite</name>
+    <description>ShopLite microservices platform</description>
+
+    <modules>
+        <module>catalog-service</module>
+    </modules>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+</project>


### PR DESCRIPTION
## Summary
- add ShopLite Maven parent project with catalog-service module
- implement catalog-service with layered architecture, DTO mapping, and error handling
- configure Flyway migrations, environment profiles, and unit tests for service and controller layers

## Testing
- mvn test *(fails: unable to download Spring Boot parent from Maven Central in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4ff36944832b9ea8625a6f2f37ce